### PR TITLE
Fix detecting metadata server.

### DIFF
--- a/compute/metadata/metadata.go
+++ b/compute/metadata/metadata.go
@@ -140,7 +140,7 @@ func testOnGCE() bool {
 	}()
 
 	go func() {
-		addrs, err := net.DefaultResolver.LookupAddr(ctx, "metadata.google.internal")
+		addrs, err := net.DefaultResolver.LookupHost(ctx, "metadata.google.internal")
 		if err != nil || len(addrs) == 0 {
 			resc <- false
 			return


### PR DESCRIPTION
This is partial revert of https://github.com/googleapis/google-cloud-go/commit/7fd52cfe4c3ca33880ed92441d7e6f7a7babe803 whe intention there was to add cancelable context but it also changed LookupHost to LookupAddr. It started causing issues for example: https://issuetracker.google.com/issues/159053735

LookupHost : https://golang.org/pkg/net/#Resolver.LookupHost ip -> DNS lookup
LookupAddr : https://golang.org/pkg/net/#Resolver.LookupAddr ip -> reverse DNS lookup